### PR TITLE
Add new armor collider info

### DIFF
--- a/RatStash/Enums.cs
+++ b/RatStash/Enums.cs
@@ -46,6 +46,54 @@ public enum ArmorType
 	Heavy,
 }
 
+public enum ArmorCollider
+{
+    BackHead,
+    Ears,
+    Eyes,
+    HeadCommon,
+    Jaw,
+    LeftCalf,
+    LeftForearm,
+    LeftSideChestDown,
+    LeftSideChestUp,
+    LeftThigh,
+    LeftUpperArm,
+    NeckBack,
+    NeckFront,
+    ParietalHead,
+    Pelvis,
+    PelvisBack,
+    RibcageLow,
+    RibcageUp,
+    RightCalf,
+    RightForearm,
+    RightSideChestDown,
+    RightSideChestUp,
+    RightThigh,
+    RightUpperArm,
+    SpineDown,
+    SpineTop
+}
+
+public enum ArmorPlateCollider
+{
+	// NATO
+    Plate_Granit_SAPI_chest,
+    Plate_Granit_SAPI_back,
+    Plate_Granit_SSAPI_side_left_high,
+    Plate_Granit_SSAPI_side_left_low,
+    Plate_Granit_SSAPI_side_right_high,
+    Plate_Granit_SSAPI_side_right_low,
+	// RU
+    Plate_Korund_chest,
+	Plate_6B13_back,
+    Plate_Korund_side_left_high,
+    Plate_Korund_side_left_low,
+    Plate_Korund_side_right_high,
+    Plate_Korund_side_right_low
+}
+
 public enum ArmorZone
 {
 	Chest,

--- a/RatStash/Item/CompoundItem/Equipment/ArmoredEquipment.cs
+++ b/RatStash/Item/CompoundItem/Equipment/ArmoredEquipment.cs
@@ -62,6 +62,25 @@ public class ArmoredEquipment : Equipment
 
 	[JsonProperty("weaponErgonomicPenalty")]
 	public int WeaponErgonomicPenalty { get; set; }
+
+	public List<ArmorCollider> GetArmorColliders()
+	{
+		List<ArmorCollider> result = new List<ArmorCollider>();
+		foreach(var slot in Slots)
+		{
+			result.AddRange(slot.Filters[0].ArmorColliders);
+		}
+		return result;
+	}
+	public List<ArmorPlateCollider> GetArmorPlateColliders()
+	{
+		List<ArmorPlateCollider> result = new List<ArmorPlateCollider>();
+		foreach(var slot in Slots)
+		{
+			result.AddRange(slot.Filters[0].ArmorPlateColliders);
+		}
+		return result;
+	}
 }
 
 public class RicochetParams

--- a/RatStash/Item/CompoundItem/Equipment/ArmoredEquipment.cs
+++ b/RatStash/Item/CompoundItem/Equipment/ArmoredEquipment.cs
@@ -54,6 +54,12 @@ public class ArmoredEquipment : Equipment
 	[JsonProperty("headSegments", ItemConverterType = typeof(StringEnumConverter))]
 	public List<HeadSegment> HeadSegments { get; set; } = new();
 
+	[JsonProperty("armorColliders", ItemConverterType = typeof(StringEnumConverter))]
+	public List<ArmorCollider> ArmorColliders { get; set; } = new();
+
+	[JsonProperty("armorPlateColliders", ItemConverterType = typeof(StringEnumConverter))]
+	public List<ArmorCollider> ArmorPlateColliders { get; set; } = new();
+
 	[JsonProperty("mousePenalty")]
 	public int MousePenalty { get; set; }
 

--- a/RatStash/Item/CompoundItem/SearchableItem/ChestRig.cs
+++ b/RatStash/Item/CompoundItem/SearchableItem/ChestRig.cs
@@ -31,6 +31,12 @@ public class ChestRig : SearchableItem
 	[JsonProperty("armorZone", ItemConverterType = typeof(StringEnumConverter))]
 	public List<ArmorZone> ArmorZone { get; set; } = new();
 
+	[JsonProperty("armorColliders", ItemConverterType = typeof(StringEnumConverter))]
+	public List<ArmorCollider> ArmorColliders { get; set; } = new();
+
+	[JsonProperty("armorPlateColliders", ItemConverterType = typeof(StringEnumConverter))]
+	public List<ArmorCollider> ArmorPlateColliders { get; set; } = new();
+
 	[JsonProperty("mousePenalty")]
 	public int MousePenalty { get; set; }
 

--- a/RatStash/Item/CompoundItem/SearchableItem/ChestRig.cs
+++ b/RatStash/Item/CompoundItem/SearchableItem/ChestRig.cs
@@ -39,4 +39,23 @@ public class ChestRig : SearchableItem
 
 	[JsonProperty("weaponErgonomicPenalty")]
 	public int WeaponErgonomicPenalty { get; set; }
+
+	public List<ArmorCollider> GetArmorColliders()
+	{
+		List<ArmorCollider> result = new List<ArmorCollider>();
+		foreach (var slot in Slots)
+		{
+			result.AddRange(slot.Filters[0].ArmorColliders);
+		}
+		return result;
+	}
+	public List<ArmorPlateCollider> GetArmorPlateColliders()
+	{
+		List<ArmorPlateCollider> result = new List<ArmorPlateCollider>();
+		foreach (var slot in Slots)
+		{
+			result.AddRange(slot.Filters[0].ArmorPlateColliders);
+		}
+		return result;
+	}
 }

--- a/RatStash/ItemFilter.cs
+++ b/RatStash/ItemFilter.cs
@@ -4,6 +4,18 @@ namespace RatStash;
 
 public class ItemFilter
 {
+	[JsonProperty("locked")]
+	public bool Locked { get; set; } = new();
+
+	[JsonProperty("Plate")]
+	public string PlateId { get; set; } = "";
+
+	[JsonProperty("armorColliders")]
+	public List<ArmorCollider> ArmorColliders { get; set; } = new();
+
+	[JsonProperty("armorPlateColliders")]
+	public List<ArmorPlateCollider> ArmorPlateColliders { get; set; } = new();
+
 	[JsonProperty("Filter")]
 	public List<string> Whitelist { get; set; } = new();
 

--- a/RatStashTest/ArmorTest.cs
+++ b/RatStashTest/ArmorTest.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using RatStash;
+using Xunit;
+using System.Linq;
+
+namespace RatStashTest;
+
+public class ArmorTest : TestEnvironment
+{
+	[Fact]
+	public void TestGettingArmorArmorRigPlateInserts()
+	{
+		var database = GetDatabase();
+		var armor = database.GetItem("545cdb794bdc2d3a198b456a");
+		var armorRig = database.GetItem("61bcc89aef0f505f0c6cd0fc");
+		var plate = database.GetItem("6575ce3716c2762fba0057fd");
+		var insert = database.GetItem("6570f71dd67d0309980a7af8");
+
+		var BuiltIns = database.GetItems(x => x is BuiltInInserts).ToList();
+
+		Assert.NotNull(armor);
+		Assert.NotNull(armorRig);
+		Assert.NotNull(plate);
+		Assert.NotNull(insert);
+		Assert.True(BuiltIns.Count > 0);
+	}
+
+	[Fact]
+	public void TestAssembleArmor()
+	{
+		var database = GetDatabase();
+		Armor item = (Armor) database.GetItem("545cdb794bdc2d3a198b456a");
+		foreach(var slot in item.Slots)
+		{
+			var plate = database.GetItem(slot.Filters[0].PlateId);
+			Assert.NotNull(item);
+			slot.ContainedItem = plate;
+		}
+		Assert.NotNull(item);
+
+		foreach(var slot in item.Slots)
+		{
+			Assert.NotNull(slot.ContainedItem);
+		}
+	}
+	[Fact]
+	public void TestGetArmorCollidersArmor()
+	{
+		var database = GetDatabase();
+		Armor item = (Armor)database.GetItem("545cdb794bdc2d3a198b456a");
+		var colliders = item.GetArmorColliders();
+		var plateColliders = item.GetArmorPlateColliders();
+		Assert.True(colliders.Count > 0);
+		Assert.True(plateColliders.Count > 0);
+	}
+	[Fact]
+	public void TestGetArmorCollidersRig()
+	{
+		var database = GetDatabase();
+		ChestRig item = (ChestRig)database.GetItem("61bcc89aef0f505f0c6cd0fc");
+		var colliders = item.GetArmorColliders();
+		var plateColliders = item.GetArmorPlateColliders();
+		Assert.True(colliders.Count > 0);
+		Assert.True(plateColliders.Count > 0);
+	}
+}

--- a/RatStashTest/TestEnvironment.cs
+++ b/RatStashTest/TestEnvironment.cs
@@ -69,6 +69,6 @@ public class TestEnvironment
 	{
 		var itemsPath = Combine(BasePath, "TestData\\items.json");
 		var localePath = Combine(BasePath, $"TestData\\locales\\{locale}.json");
-		return Database.FromFile(itemsPath, cleaned, localePath).Filter(i => i.Name != "" && i.ShortName != "");
+		return Database.FromFile(itemsPath, cleaned, localePath);
 	}
 }


### PR DESCRIPTION
What used to be Armor Zones are now Armor (Plate) Colliders. They now belong to the slot for an insert to be placed, and not with the parent object itself. As such I've also added in some getter methods to make it neater to get a summary list of each type of zone for the parent object.